### PR TITLE
Add return to functions returning non-void

### DIFF
--- a/Tasker.h
+++ b/Tasker.h
@@ -33,11 +33,11 @@ public:
 	bool cancel(TaskCallback0 func);
 	bool cancel(TaskCallback1 func, int param);
 
-	bool clearTimeout(TaskCallback0 func) { cancel(func); };
-	bool clearTimeout(TaskCallback1 func, int param) { cancel(func, param); };
+	bool clearTimeout(TaskCallback0 func) { return cancel(func); };
+	bool clearTimeout(TaskCallback1 func, int param) { return cancel(func, param); };
 
-	bool clearInterval(TaskCallback0 func) { cancel(func); };
-	bool clearInterval(TaskCallback1 func, int param) { cancel(func, param); };
+	bool clearInterval(TaskCallback0 func) { return cancel(func); };
+	bool clearInterval(TaskCallback1 func, int param) { return cancel(func, param); };
 
 	unsigned long scheduledIn(TaskCallback0 func);
 	unsigned long scheduledIn(TaskCallback1 func, int param);


### PR DESCRIPTION
If all warnings are enabled, Arduino IDE shows the output below. Adding a return statement to all functions returning non-void fixes it.
```

In file included from C:\Users\xxx_ADMIN\Alberto_xxx\GitHub\EVA_Arduino_hub\I2C_to_serial\I2C_to_serial.ino:7:0:

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h: In member function 'bool Tasker::clearTimeout(TaskCallback0)':

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h:36:56: warning: no return statement in function returning non-void [-Wreturn-type]

  bool clearTimeout(TaskCallback0 func) { cancel(func); };

                                                        ^

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h: In member function 'bool Tasker::clearTimeout(TaskCallback1, int)':

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h:37:74: warning: no return statement in function returning non-void [-Wreturn-type]

  bool clearTimeout(TaskCallback1 func, int param) { cancel(func, param); };

                                                                          ^

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h: In member function 'bool Tasker::clearInterval(TaskCallback0)':

C:\Users\xxx_ADMIN\Documents\Arduino\libraries\Tasker/Tasker.h:39:57: warning: no return statement in function returning non-void [-Wreturn-type]

  bool clearInterval(TaskCallback0 func) { cancel(func); };

                                                         ^
```